### PR TITLE
Support scopes with arguments

### DIFF
--- a/lib/solargraph/arc/model.rb
+++ b/lib/solargraph/arc/model.rb
@@ -30,13 +30,20 @@ module Solargraph
         walker.on :send, [nil, :scope] do |ast|
           name = ast.children[2].children.last
 
-          pins << Util.build_public_method(
+          method_pin = Util.build_public_method(
             ns,
             name.to_s,
             types: ns.return_type.map(&:tag),
             scope: :class,
             location: Util.build_location(ast, ns.filename)
           )
+
+          if ast.children.last.type == :block
+            location = ast.children.last.location
+            block_pin = source_map.locate_block_pin(location.line, location.column)
+            method_pin.parameters.concat(block_pin.parameters.clone)
+          end
+          pins << method_pin
         end
 
         walker.walk

--- a/spec/solargraph-arc/model_spec.rb
+++ b/spec/solargraph-arc/model_spec.rb
@@ -54,5 +54,22 @@ RSpec.describe Solargraph::Arc::Model do
       ["Class<Transaction>"]
     )
   end
+
+  it "generates scope methods with parameters" do
+    load_string 'app/models/person.rb', <<-RUBY
+      class Person < ActiveRecord::Base
+        scope :taller_than, ->(min_height) { where("height > ?", min_height) }
+      end
+    RUBY
+
+    assert_class_method(
+      api_map,
+      "Person.taller_than",
+      ["Class<Person>"]
+    ) do |pin|
+      expect(pin.parameters).not_to be_empty
+      expect(pin.parameters.first.name).to eq("min_height")
+    end
+  end
 end
 


### PR DESCRIPTION
I noticed that the class methods generated to handle scopes are always created with no parameters. However, ActiveRecord supports creating scopes with lambdas that accept (or require) parameters, and I use that quite a lot. This PR adds support for that (and also a simple test case).
