### PR TITLE
Support custom class names in association methods

### DIFF
--- a/lib/solargraph/arc/model.rb
+++ b/lib/solargraph/arc/model.rb
@@ -44,28 +44,38 @@ module Solargraph
         pins
       end
 
-      # TODO: handle custom class for relation
       def plural_association(ns, ast)
         relation_name = ast.children[2].children.first
+        class_name = extract_custom_class_name(ast) || relation_name.to_s.singularize.camelize
 
         Util.build_public_method(
           ns,
           relation_name.to_s,
-          types: ["ActiveRecord::Associations::CollectionProxy<#{relation_name.to_s.singularize.camelize}>"],
+          types: ["ActiveRecord::Associations::CollectionProxy<#{class_name}>"],
           location: Util.build_location(ast, ns.filename)
         )
       end
 
-      # TODO: handle custom class for relation
       def singular_association(ns, ast)
         relation_name = ast.children[2].children.first
+        class_name = extract_custom_class_name(ast) || relation_name.to_s.camelize
 
         Util.build_public_method(
           ns,
           relation_name.to_s,
-          types: [relation_name.to_s.camelize],
+          types: [class_name],
           location: Util.build_location(ast, ns.filename)
         )
+      end
+
+      def extract_custom_class_name(ast)
+        options = ast.children[3..-1].find { |n| n.type == :hash }
+        return unless options
+
+        class_name_pair = options.children.find do |n|
+          n.children[0].deconstruct == [:sym, :class_name] && n.children[1].type == :str
+        end
+        class_name_pair && class_name_pair.children.last.children.last
       end
     end
   end

--- a/spec/solargraph-arc/model_spec.rb
+++ b/spec/solargraph-arc/model_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Solargraph::Arc::Model do
     assert_public_instance_method(api_map, "Transaction#category", ["Category"])
   end
 
+  it "generates methods for association with custom class_name" do
+    load_string 'app/models/transaction.rb', <<-RUBY
+      class Transaction < ActiveRecord::Base
+        belongs_to :account, class_name: 'CustomAccount'
+      end
+    RUBY
+
+    assert_public_instance_method(api_map, "Transaction#account", ["CustomAccount"])
+  end
+
   it "generates methods for plural associations" do
     load_string 'app/models/account.rb', <<-RUBY
       class Account < ActiveRecord::Base


### PR DESCRIPTION
This adds support for `class_name: 'SomeClass'` to the `has_one`/`has_many`/`belongs_to` association methods.

I didn't add a spec for the plural association case yet, because it's using the same code as the singular one.
